### PR TITLE
AWS::Route53::HostedZone

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Implemented resources:
 
 * AWS::EC2::Subnet
 * AWS::EC2::VPC
+* AWS::Route53:HostedZone
 
 more to come ...

--- a/dp-lambda.yml
+++ b/dp-lambda.yml
@@ -26,6 +26,7 @@ Resources:
                 Action:
                   - ec2:DescribeSubnets
                   - ec2:DescribeVpcs
+                  - route53:GetHostedZone
                 Resource: "*"
         - PolicyName: wo-lambda-cloudwatch-logs
           PolicyDocument:
@@ -42,12 +43,12 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       FunctionName: cfn-dataprovider
-      Description: Look up info from a VPC or subnet ID
+      Description: Look up info from a VPC, subnet ID or R53 zone
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt LambdaExecutionRole.Arn
       Runtime: "python3.7"
-      Timeout: 30
+      Timeout: 10
       Code:
         ZipFile: |
           import json
@@ -70,16 +71,27 @@ Resources:
                   flat_filter.append(condition)
               return flat_filter
 
+          def flat_out_dict(d, flat=dict(), prefix=""):
+            """ Flat out dict so all attributes can be accessed with GetAtt """
+            for k,v in d.items():
+              if prefix == "":
+                key = str(k)
+              else:
+                key = prefix + "." + str(k)
+              if isinstance(v, dict):
+                flat_out_dict(v, flat, key)
+              else:
+                flat[key]=str(v)
+            return(flat)
 
           def handler(event, context):
               """Main Lambda Function"""
               response_data = {}
 
               log.debug("Received event: %s", json.dumps(event))
-              filters = flat_out_filter(event["ResourceProperties"]["Filter"])
+              try: filters = flat_out_filter(event["ResourceProperties"]["Filter"])
+              except KeyError: filters = []
               log.debug("Where filters are: %s", filters)
-              # Let's init the boto2 clients
-              ec2 = boto3.client("ec2")
 
               if event["RequestType"] == "Delete":
                   response_status = cfnresponse.SUCCESS
@@ -88,6 +100,7 @@ Resources:
 
               if event["ResourceType"] == "Custom::Subnet":
                   log.debug("Subnet lookup")
+                  ec2 = boto3.client("ec2")
                   search = ec2.describe_subnets(Filters=filters)
                   if len(search["Subnets"]) == 1:
                       subnet = search["Subnets"][0]
@@ -99,6 +112,7 @@ Resources:
 
               elif event["ResourceType"] == "Custom::VPC":
                   log.debug("VPC lookup")
+                  ec2 = boto3.client("ec2")
                   search = ec2.describe_vpcs(Filters=filters)
                   if len(search["Vpcs"]) == 1:
                       vpc = search["Vpcs"][0]
@@ -107,6 +121,20 @@ Resources:
                   else:
                       response_status = cfnresponse.FAILED
                       cfnresponse.send(event, context, response_status, response_data)
+              
+              elif event["ResourceType"] == "Custom::R53HostedZone":
+                  log.debug("R53 Hosted Zone lookup")
+                  r53 = boto3.client("route53")
+                  try: zone_id = event["ResourceProperties"]["HostedZoneId"]
+                  except KeyError: zone_id = None
+                  zone = r53.get_hosted_zone(Id=zone_id)        
+                  if zone:
+                      response_status = cfnresponse.SUCCESS
+                      cfnresponse.send(event, context, response_status, flat_out_dict(zone), zone_id)
+                  else:
+                      response_status = cfnresponse.FAILED
+                      cfnresponse.send(event, context, response_status, response_data)
+
               else:
                   log.error("Unsupported resource lookup")
                   response_status = cfnresponse.FAILED

--- a/dp-sample.yml
+++ b/dp-sample.yml
@@ -3,26 +3,37 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Data provider for AWS services
 
 Parameters:
+  HostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: Route53 Hosted Zone ID
   Version:
     Type: Number
     Description: "Just for testing"
     Default: 1
 
-
 Resources:
-  # VpcInfo - VPC Lookup
+  ZoneInfo:
+    Type: Custom::R53HostedZone
+    Properties:
+      ServiceToken:
+        Fn::ImportValue: !Sub "cfn:cfn-dataprovider:${AWS::Region}:arn"
+      HostedZoneId: !Ref HostedZoneId
+      Tags:
+        - Key: Version
+          Value: !Ref Version
+
   SubnetInfo:
     Type: Custom::Subnet
     Properties:
       ServiceToken:
         Fn::ImportValue: !Sub "cfn:cfn-dataprovider:${AWS::Region}:arn"
       Filter:  # For more options check https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_subnets
-        cidr: 172.31.32.0/20
-        default-for-az: True
+        #cidr: 172.31.32.0/20
+        default-for-az: False
         state: available
-        availability-zone: eu-west-2b
-        tag-key: blue
-        "tag:Name": subnetname
+        availability-zone: !Sub '${AWS::Region}a'
+        #tag-key: blue
+        #"tag:Name": subnetname
       Tags:
         - Key: Version
           Value: !Ref Version
@@ -35,8 +46,16 @@ Resources:
       Filter:  # For more options check https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_vpcs
         vpc-id: !GetAtt SubnetInfo.VpcId
 
-
 Outputs:
+  HostedZoneName:
+    Description: "Hosted Zone Name"
+    Value: !GetAtt ZoneInfo.HostedZone.Name
+  HostedZoneRecords:
+    Description: "Number of Records"
+    Value: !GetAtt ZoneInfo.HostedZone.ResourceRecordSetCount
+  PrivateZone:
+    Description: "Is that private zone"
+    Value: !GetAtt ZoneInfo.HostedZone.Config.PrivateZone
   SubnetID:
     Description: "SubnetID"
     Value: !Ref SubnetInfo

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -18,16 +18,27 @@ def flat_out_filter(cfn_filter):
         flat_filter.append(condition)
     return flat_filter
 
+def flat_out_dict(d, flat=dict(), prefix=""):
+    """ Flat out dict so all attributes can be accessed with GetAtt """
+    for k,v in d.items():
+        if prefix == "":
+            key = str(k)
+        else:
+            key = prefix + "." + str(k)
+        if isinstance(v, dict):
+            flat_out_dict(v, flat, key)
+        else:
+            flat[key]=str(v)
+    return(flat)
 
 def handler(event, context):
     """Main Lambda Function"""
     response_data = {}
 
     log.debug("Received event: %s", json.dumps(event))
-    filters = flat_out_filter(event["ResourceProperties"]["Filter"])
+    try: filters = flat_out_filter(event["ResourceProperties"]["Filter"])
+    except KeyError: filters = []
     log.debug("Where filters are: %s", filters)
-    # Let's init the boto2 clients
-    ec2 = boto3.client("ec2")
 
     if event["RequestType"] == "Delete":
         response_status = cfnresponse.SUCCESS
@@ -36,6 +47,7 @@ def handler(event, context):
 
     if event["ResourceType"] == "Custom::Subnet":
         log.debug("Subnet lookup")
+        ec2 = boto3.client("ec2")
         search = ec2.describe_subnets(Filters=filters)
         if len(search["Subnets"]) == 1:
             subnet = search["Subnets"][0]
@@ -47,6 +59,7 @@ def handler(event, context):
 
     elif event["ResourceType"] == "Custom::VPC":
         log.debug("VPC lookup")
+        ec2 = boto3.client("ec2")
         search = ec2.describe_vpcs(Filters=filters)
         if len(search["Vpcs"]) == 1:
             vpc = search["Vpcs"][0]
@@ -55,6 +68,20 @@ def handler(event, context):
         else:
             response_status = cfnresponse.FAILED
             cfnresponse.send(event, context, response_status, response_data)
+    
+    elif event["ResourceType"] == "Custom::R53HostedZone":
+        log.debug("R53 Hosted Zone lookup")
+        r53 = boto3.client("route53")
+        try: zone_id = event["ResourceProperties"]["HostedZoneId"]
+        except KeyError: zone_id = None
+        zone = r53.get_hosted_zone(Id=zone_id)        
+        if zone:
+            response_status = cfnresponse.SUCCESS
+            cfnresponse.send(event, context, response_status, flat_out_dict(zone), zone_id)
+        else:
+            response_status = cfnresponse.FAILED
+            cfnresponse.send(event, context, response_status, response_data)
+
     else:
         log.error("Unsupported resource lookup")
         response_status = cfnresponse.FAILED


### PR DESCRIPTION
Here is R53 hosted zone data provider. Primary case-use is mapping zone id to name and then use name to construct hostnames etc. This doesn't support getting zone id from zone name as there can be multiple zones with the same name. Filtering is now optional as R53 API doesn't support it.